### PR TITLE
Return success result from track event method

### DIFF
--- a/src/appcenter_analytics/android/src/main/java/com/aloisdeniel/flutter/appcenter_analytics/AppcenterAnalyticsPlugin.java
+++ b/src/appcenter_analytics/android/src/main/java/com/aloisdeniel/flutter/appcenter_analytics/AppcenterAnalyticsPlugin.java
@@ -59,6 +59,7 @@ public class AppcenterAnalyticsPlugin implements MethodCallHandler {
         String name = call.argument("name");
         Map<String, String> properties = call.argument("properties");
         Analytics.trackEvent(name, properties);
+        result.success(null);
         break;
       default:
         result.notImplemented();


### PR DESCRIPTION
On android the call to track event never returns a success so if you await the call in Dart it will never complete.